### PR TITLE
Added - Disable and Close any Lightning Channel - Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,4 +233,145 @@ You need Balance of Satoshis (BOS) installed
 
 **Done!**
 
+##
 
+# [Disable and Close any Lightning Channel - Script](https://github.com/jvxis/nr-tools/blob/main/closechannel.py)
+
+This repository contains a Python script designed to disable a specific Lightning Network channel using `charge-lnd` before closing it. The script checks for pending HTLCs, ensures that the channel remains disabled, and uses dynamic fee rates to close the channel efficiently.
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Example Screenshot](#example-screenshot)
+- [Running With Screen](#running-the-script-automatically-with-screen)
+
+## Requirements
+
+Before running the script, ensure you have the following installed:
+
+- **Python 3.7+**
+- **lncli** (part of LND)
+- **charge-lnd** ([charge-lnd GitHub repository](https://github.com/accumulator/charge-lnd))
+- **LNDg** ([LNDg Github](https://github.com/cryptosharks131/lndg))
+- **Requests library** (Python library for HTTP requests)
+
+## Installation
+
+### 1. **Install Python dependencies:**
+
+Ensure you have requests installed:
+```
+pip install requests
+```
+
+### 2. **Install and configure charge-lnd:**
+
+Follow the instructions on the official [charge-lnd GitHub](https://github.com/accumulator/charge-lnd) repository to install and configure charge-lnd on your system.
+
+## Usage
+
+### 1. **Run the Script**
+
+To run the script, execute the following command:
+
+```
+python3 closechannel.py
+```
+
+### 2. **Follow the On-Screen Instructions**
+
+* Enter the desired max_fee_rate: This is the maximum fee rate in sat/vbyte that you are willing to pay to close the channel.
+* Enter the Channel ID: Provide the channel ID (chan_id) of the channel you wish to disable and close.**
+
+### 3. **Watch the Script in Action**
+
+### 4. **The script will:**
+
+* Disable the channel by creating/updating a configuration file in the specified directory.
+* Run charge-lnd to apply the configuration and disable the channel.
+* Check for pending HTLCs and wait until they are cleared.
+* Re-run charge-lnd periodically to ensure the channel remains disabled.
+* Close the channel using the specified fee rate or a dynamic fee rate obtained from Mempool.Space.
+
+### 5. **Monitor the Output**
+
+* The script provides detailed output, showing each step of the process, including any errors encountered.
+
+## Example Screenshot
+
+![image](https://github.com/user-attachments/assets/d34e7650-2387-4695-a548-80dcf737261b)
+
+## Running the Script Automatically with `screen`
+
+To avoid manually monitoring the script in the terminal, you can run it in a `screen` session. This allows the script to continue running in the background, even if you disconnect from your session. You can also reattach to the session later to check on the progress.
+
+### Step-by-Step Guide:
+
+### 1. **Install `screen` (if not already installed)**
+
+If `screen` is not already installed, you can install it using your package manager:
+
+- **Debian/Ubuntu:**
+
+```
+  sudo apt-get install screen
+```
+
+### 2. **Start a new screen session**
+
+Open your terminal and navigate to the directory where the script is located:
+
+``` 
+cd /path/to/your-repository
+```
+Start a new screen session with a name of your choice:
+
+```
+screen -S <name_of_your_choice>
+```
+
+### 3. **Run the script inside the screen session**
+
+Once inside the screen session, run your Python script:
+
+```
+python3 closechannel.py
+```
+
+### 4. **Detach from the screen session**
+
+You can now detach from the screen session and leave the script running in the background:
+
+* Detach from the session by pressing Ctrl + A, then D.
+
+Your script will continue running even after you close the terminal.
+
+### 5. **Reattach to the screen session later**
+
+* If you want to check on the progress or logs of the running script, you can reattach to the screen session:
+
+List all running screen sessions to find your session name:
+
+```
+screen -ls
+```
+
+Reattach to your session:
+
+```
+screen -r <your_session_name>
+```
+
+Now, you can see the output of your script and interact with it if necessary.
+
+### 6. **Exit the screen session when done**
+
+When your script has finished and you no longer need the session, you can exit the screen session by simply typing:
+
+```
+exit
+```
+
+This will close the session.

--- a/closechannel.py
+++ b/closechannel.py
@@ -1,0 +1,151 @@
+import subprocess
+import time
+import sqlite3
+import json
+import os
+import requests
+
+user_path = os.path.expanduser("~")
+db_path = os.path.join(user_path, "lndg/data/db.sqlite3")
+charge_lnd_bin = "charge-lnd"
+charge_lnd_config_dir = os.path.join(user_path, "charge-lnd/")
+mempool_api_url = "https://mempool.space/api/v1/fees/recommended"
+charge_lnd_interval = 300
+
+def create_or_update_config(chan_id):
+    config_path = os.path.join(charge_lnd_config_dir, f"{chan_id}.conf")
+    config_lines = []
+
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            config_lines = f.readlines()
+
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(config_lines):
+        if line.strip().lower() == '[disable-channels]':
+            start_idx = i
+            for j in range(i + 1, len(config_lines)):
+                if config_lines[j].startswith('['):
+                    end_idx = j
+                    break
+            break
+    
+    if start_idx is not None:
+        config_lines[start_idx + 1:end_idx] = [
+            f"chan.id = {chan_id}\n",
+            "strategy = disable\n"
+        ]
+    else:
+        config_lines.append("\n[disable-channels]\n")
+        config_lines.append(f"chan.id = {chan_id}\n")
+        config_lines.append("strategy = disable\n")
+
+    with open(config_path, 'w') as f:
+        f.writelines(config_lines)
+
+    return config_path
+
+def execute_charge_lnd(config_path):
+    result = subprocess.run(
+        [charge_lnd_bin, "-c", config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+    print("charge-lnd output:\n", result.stdout)
+    if result.stderr:
+        print("charge-lnd errors:\n", result.stderr)
+
+def get_channel_info(chan_id):
+    command = ["lncli", "getchaninfo", chan_id]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    else:
+        print(f"Error fetching channel info: {result.stderr}")
+        return None
+
+def close_channel(funding_txid, output_index, sat_per_vbyte):
+    command = [
+        "lncli", "closechannel", 
+        "--funding_txid", funding_txid, 
+        "--output_index", str(output_index), 
+        "--sat_per_vbyte", str(sat_per_vbyte)
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode == 0:
+        print(f"Channel closed successfully: {result.stdout}")
+        return True
+    else:
+        print(f"Error closing channel: {result.stderr}")
+        return False
+
+def check_pending_htlcs(chan_id, db_path):
+    print(f"Trying to open database at: {db_path}")
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM gui_pendinghtlcs WHERE chan_id = ?", (chan_id,))
+    pending_htlcs = cursor.fetchall()
+    conn.close()
+    if pending_htlcs:
+        print(f"Pending HTLC found for channel {chan_id}. Total pending HTLCs: {len(pending_htlcs)}. Retrying in 1 minute...")
+        return True
+    return False
+
+def get_high_priority_fee():
+    response = requests.get(mempool_api_url)
+    if response.status_code == 200:
+        fees = response.json()
+        return fees.get("fastestFee", None)
+    else:
+        print(f"Error accessing Mempool.Space API: {response.status_code}")
+        return None
+
+def main():
+    max_fee_rate = int(input("Enter the desired max_fee_rate (sat/vbyte): "))
+    
+    chan_id = input("Enter the Channel ID (chan_id): ")
+    config_path = create_or_update_config(chan_id)
+    execute_charge_lnd(config_path)
+    
+    channel_info = get_channel_info(chan_id)
+    
+    if channel_info:
+        if "chan_point" in channel_info:
+            channel_point = channel_info["chan_point"]
+            funding_txid, output_index = channel_point.split(':')
+        else:
+            print("Error: 'chan_point' not found in the channel info.")
+            return
+
+        last_charge_lnd_time = time.time()
+        
+        while True:
+            if time.time() - last_charge_lnd_time >= charge_lnd_interval:
+                execute_charge_lnd(config_path)
+                last_charge_lnd_time = time.time()
+
+            pending_htlcs_exist = check_pending_htlcs(chan_id, db_path)
+            if not pending_htlcs_exist:
+                high_priority_fee = get_high_priority_fee()
+                
+                if high_priority_fee is not None:
+                    print(f"High priority fee obtained: {high_priority_fee} sat/vbyte.")
+                    if high_priority_fee <= max_fee_rate:
+                        print(f"Using high priority fee of {high_priority_fee} sat/vbyte to close the channel.")
+                        if close_channel(funding_txid, output_index, high_priority_fee):
+                            break
+                    else:
+                        print(f"The high priority fee ({high_priority_fee} sat/vbyte) is greater than the max_fee_rate ({max_fee_rate} sat/vbyte).")
+                        print(f"Using max_fee_rate of {max_fee_rate} sat/vbyte to close the channel.")
+                        if close_channel(funding_txid, output_index, max_fee_rate):
+                            break
+                else:
+                    print("Failed to retrieve high priority fee. Retrying in 1 minute...")
+            time.sleep(60)
+    else:
+        print("Failed to retrieve channel info.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This repository contains a Python script designed to disable a specific Lightning Network channel using charge-lnd before closing it. The script checks for pending HTLCs, ensures that the channel remains disabled, and uses dynamic fee rates to close the channel efficiently.